### PR TITLE
Detect tty

### DIFF
--- a/src/black_gl_code_quality/__main__.py
+++ b/src/black_gl_code_quality/__main__.py
@@ -28,7 +28,7 @@ def main():
 
     if sys.stdin.isatty():
         res = subprocess.run(
-            ["black", "--check", *sys.argv[1:]],
+            ["black", "--check", *args],
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
         )

--- a/src/black_gl_code_quality/__main__.py
+++ b/src/black_gl_code_quality/__main__.py
@@ -26,7 +26,7 @@ def main():
         verbose = True
         args.remove("-v")
 
-    if not stdin.closed:
+    if sys.stdin.isatty():
         res = subprocess.run(
             ["black", "--check", *sys.argv[1:]],
             stdout=subprocess.PIPE,


### PR DESCRIPTION
- `if not stdin.closed` returns true even if piping in output of `black`
  - this can cause the second black to return exitcode 1
  - use `if sys.stdin.isatty()` instead to determine if stdin is interactive or not
- pass `*args` to `subprocess.run`, removing `-v` from args to `black`
  - use `black-gl-cq -v -v` to get verbose from `black` too

before:
```
$ black --check . ; echo $?
All done! ✨ 🍰 ✨
4 files would be left unchanged.
0
$ black --check . 2>&1 | black-gl-cq -v ; echo $?
Usage: black [OPTIONS] SRC ...

One of 'SRC' or 'code' is required.

[]
1

$ black-gl-cq -v .
Identified `/src` as project root containing a .git directory.
Found input source directory: "/src"
/src/.git ignored: matches the --exclude regular expression
/src/src/black_gl_code_quality/__init__.py wasn't modified on disk since last run.
/src/src/black_gl_code_quality/__main__.py wasn't modified on disk since last run.
/src/src/black_gl_code_quality/error.py wasn't modified on disk since last run.
/src/src/black_gl_code_quality/parser.py wasn't modified on disk since last run.

All done! ✨ 🍰 ✨
4 files would be left unchanged.

[]
```

after:
```
$ black --check . 2>&1 | black-gl-cq -v ; echo $?
All done! ✨ 🍰 ✨
4 files would be left unchanged.

[]
0

$ black-gl-cq -v .
All done! ✨ 🍰 ✨
4 files would be left unchanged.

[]
$ black-gl-cq -v -v .
Identified `/src` as project root containing a .git directory.
Found input source directory: "/src"
/src/.git ignored: matches the --exclude regular expression
/src/src/black_gl_code_quality/__init__.py wasn't modified on disk since last run.
/src/src/black_gl_code_quality/__main__.py wasn't modified on disk since last run.
/src/src/black_gl_code_quality/error.py wasn't modified on disk since last run.
/src/src/black_gl_code_quality/parser.py wasn't modified on disk since last run.

All done! ✨ 🍰 ✨
4 files would be left unchanged.

[]
```